### PR TITLE
新增查詢favorite list api

### DIFF
--- a/demo/src/main/java/com/example/demo/Component/GetFavoriteListParam.java
+++ b/demo/src/main/java/com/example/demo/Component/GetFavoriteListParam.java
@@ -1,0 +1,21 @@
+package com.example.demo.Component;
+
+ import javax.validation.constraints.Email;
+ import javax.validation.constraints.NotEmpty;
+
+ import lombok.Data;
+
+ @Data
+ public class GetFavoriteListParam {
+     @NotEmpty(message = "member_account不可為空")
+     @Email(message = "必須email格式")
+     private String account;
+
+     private String list_name;
+
+     public GetFavoriteListParam(String member_account, String favorite_list_name) {
+         super();
+         this.account = member_account;
+         this.list_name = favorite_list_name;
+     }
+ }

--- a/demo/src/main/java/com/example/demo/Entity/FavoriteListId.java
+++ b/demo/src/main/java/com/example/demo/Entity/FavoriteListId.java
@@ -1,0 +1,32 @@
+package com.example.demo.Entity;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+
+@Data
+@Embeddable
+public class FavoriteListId implements Serializable {
+    @Column(name="mid", nullable = false, columnDefinition = "BINARY(36)")
+    private String mid;
+
+    @NonNull
+    @NotBlank
+    @Column(name="favorite_list_name", nullable = false, length = 30)
+    private String favorite_list_name;
+
+    @Column(name="stock_id", length = 15)
+    private String stock_id;
+
+    public FavoriteListId(String mid, String favorite_list_name, String stock_id) {
+        this.mid = mid;
+        this.favorite_list_name = favorite_list_name;
+        this.stock_id = stock_id;
+    }
+
+    public FavoriteListId(){
+    }
+}

--- a/demo/src/main/java/com/example/demo/Entity/FavoriteListModel.java
+++ b/demo/src/main/java/com/example/demo/Entity/FavoriteListModel.java
@@ -1,0 +1,47 @@
+package com.example.demo.Entity;
+
+import lombok.*;
+
+import java.util.Date;
+import javax.persistence.*;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Entity
+@Data
+@Table(name="favorite_list")
+@EntityListeners(AuditingEntityListener.class)
+public class FavoriteListModel {
+
+    @EmbeddedId
+    private FavoriteListId favoriteListsId;
+
+    @Column(name="stock_name", length = 50)
+    private String stock_name;
+
+    @Column(name="list_status", length = 2)
+    private String list_status;
+
+    @Column(name="comments", length = 200)
+    private String comments_string;
+
+    @CreatedDate
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="create_time", updatable = false)
+    private Date create_time;
+    
+    @Column(name="create_user", updatable = false, nullable = true, length = 10)
+    private String create_user;
+
+    @LastModifiedDate
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="update_time")
+    private Date update_time;
+
+    @Column(name="update_user", updatable=true, nullable = true, length = 10)
+    private String update_user;
+}

--- a/demo/src/main/java/com/example/demo/Repository/FavoriteListRespository.java
+++ b/demo/src/main/java/com/example/demo/Repository/FavoriteListRespository.java
@@ -1,0 +1,18 @@
+package com.example.demo.Repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.Entity.FavoriteListModel;
+import com.example.demo.Entity.FavoriteListId;
+
+@Repository
+public interface FavoriteListRespository extends JpaRepository<FavoriteListModel, FavoriteListId> {
+    @Query(nativeQuery = true, value = "select * from favorite_list where mid = ?1 and favorite_list_name = ?2")
+    public List<FavoriteListModel> FindByListName(String mid, String list_name);  
+    
+    @Query(nativeQuery = true, value = "select * from favorite_list where mid = ?1")
+    public List<FavoriteListModel> FindListByMid(String mid);  
+}

--- a/demo/src/main/java/com/example/demo/Service/MemberService.java
+++ b/demo/src/main/java/com/example/demo/Service/MemberService.java
@@ -1,13 +1,20 @@
 package com.example.demo.Service;
 
+import com.example.demo.Component.GetFavoriteListParam;
 import com.example.demo.Component.MemberRegisterParam;
+import com.example.demo.Entity.FavoriteListModel;
 import com.example.demo.Entity.MemberModel;
+import com.example.demo.Repository.FavoriteListRespository;
 import com.example.demo.Repository.MemberRespository;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import lombok.Data;
+import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 @Data
@@ -15,9 +22,41 @@ import net.sf.json.JSONObject;
 public class MemberService {
     @Autowired
     private MemberRespository MemberRepo;
+    @Autowired
+    private FavoriteListRespository favoriteListRespository;
     public MemberService() {
     }
     
+    public JSONObject getFavoriteList(GetFavoriteListParam data) {
+        MemberModel memberModel = new MemberModel();
+        List<FavoriteListModel> favoriteModel_list = new ArrayList<FavoriteListModel>();
+        JSONArray result_array= new JSONArray();
+
+        //Check member exists ,and get mid.
+        if((memberModel = MemberRepo.FindByAccount(data.getAccount())) == null) {
+            return responseError("會員帳號尚未建立");
+        }
+
+        favoriteModel_list = data.getList_name().equals("") 
+            ? favoriteListRespository.FindListByMid(memberModel.getMid()) 
+            : favoriteListRespository.FindByListName(memberModel.getMid(), data.getList_name());
+            
+        if(favoriteModel_list.size() == 0) {
+            return responseError("查無資料");
+        }
+
+        for (FavoriteListModel items : favoriteModel_list) {
+            JSONObject object = new JSONObject();
+            object.element("list_name", items.getFavoriteListsId().getFavorite_list_name());
+            object.element("stock_id", items.getFavoriteListsId().getStock_id());
+            object.element("stock_name", items.getStock_name());
+            object.element("comments", items.getComments_string());
+            
+            result_array.add(object);
+        }
+        return responseJSONArraySuccess(result_array);
+    }
+
     public JSONObject createMember(MemberRegisterParam data) {
         //檢核會員帳號是否存在
         if((MemberRepo.FindByAccount(data.getAccount())) != null) {
@@ -35,10 +74,22 @@ public class MemberService {
         memberModel.setUpdate_user("system");
         MemberRepo.save(memberModel);
 
-        return responseCreateMemberSuccess();
+        return responseSuccess();
+    }
+    
+    private JSONObject responseJSONArraySuccess(JSONArray data) {
+        JSONObject status_code = new JSONObject();
+        JSONObject result = new JSONObject();
+
+        status_code.put("status", "success");
+        status_code.put("desc", "");
+
+        result.put("metadata", status_code);
+        result.put("data", data);
+        return result;
     }
 
-    private JSONObject responseCreateMemberSuccess() {
+    private JSONObject responseSuccess() {
         JSONObject data = new JSONObject();
         JSONObject status_code = new JSONObject();
         JSONObject result = new JSONObject();

--- a/demo/src/main/java/com/example/demo/controller/MemberController.java
+++ b/demo/src/main/java/com/example/demo/controller/MemberController.java
@@ -6,12 +6,10 @@ import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.example.demo.Component.MemberRegisterParam;
+import com.example.demo.Component.GetFavoriteListParam;
 import com.example.demo.Service.MemberService;
 
 @RestController
@@ -19,13 +17,21 @@ import com.example.demo.Service.MemberService;
 public class MemberController {
     @Autowired
     MemberService memberService;
-
     @PostMapping("/member/createMember")
-    @CrossOrigin(origins = "*", allowedHeaders = "*")
     public JSONObject createMember(@Valid @RequestBody MemberRegisterParam input) {
-        try {
+        try{
             return memberService.createMember(input);
-        } catch (Exception io) {
+        }catch(Exception io){
+            return memberService.responseError(io.toString());
+        }
+    }
+
+    @PostMapping("/member/searchFavoriteList")
+    @CrossOrigin(origins = "http://localhost:5277", allowedHeaders = "")
+    public JSONObject getFavoriteList(@Valid @RequestBody GetFavoriteListParam input) {
+        try{
+            return memberService.getFavoriteList(input);
+        }catch(Exception io){
             return memberService.responseError(io.toString());
         }
     }


### PR DESCRIPTION
1. member_account 必填，favorite_list_name選填
2. 可單一查詢member_account底下所有的list；
 member_account及 favorite_list_name皆有填入，則查詢該會員的指定list裡所有的data

request body :
{
    "member_account":"a123454@gmail.com.tw",
    "favorite_list_name":""
}
reponse body:
"data": [
        {
            "list_name": "change change",
            "stock_id": "1240",
            "stock_name": "w",
            "comments": "ww"
        },
        {
            "list_name": "change change",
            "stock_id": "2330",
            "stock_name": "gg",
            "comments": "ewew"
        },
        {
            "list_name": "test name",
            "stock_id": ""
        }
    ]